### PR TITLE
Correct package header format

### DIFF
--- a/sudo-ext.el
+++ b/sudo-ext.el
@@ -1,4 +1,4 @@
-;;;; sudo-ext.el --- sudo support
+;;; sudo-ext.el --- sudo support
 ;; Time-stamp: <2011-01-17 15:52:34 rubikitch>
 
 ;; Copyright (C) 2010  rubikitch


### PR DESCRIPTION
Semicolons are three, not four.